### PR TITLE
Screen Rect fix for Canvas mode Screen Space Camera.

### DIFF
--- a/Runtime/MobileInputField.cs
+++ b/Runtime/MobileInputField.cs
@@ -332,8 +332,11 @@ namespace Mopsicus.Plugins {
 			float yMax = float.NegativeInfinity;
 			for (int i = 0; i < 4; i++) {
 				Vector3 screenCoord;
-				if (rect.GetComponentInParent<Canvas> ().renderMode == RenderMode.ScreenSpaceOverlay) {
+				Canvas canvas = rect.GetComponentInParent<Canvas> ();
+				if (canvas.renderMode == RenderMode.ScreenSpaceOverlay) {
 					screenCoord = corners[i];
+				} else if (canvas.renderMode == RenderMode.ScreenSpaceCamera) {
+					screenCoord = canvas.worldCamera.WorldToScreenPoint (corners[i]);
 				} else {
 					screenCoord = RectTransformUtility.WorldToScreenPoint (Camera.main, corners[i]);
 				}


### PR DESCRIPTION
Correct computes the Screen Rect if canvas render mode is set to Screen Space Camera.