### PR TITLE
fix android caret when setting text

### DIFF
--- a/Android~/plugin/src/main/java/com/mopsicus/umi/MobileInput.java
+++ b/Android~/plugin/src/main/java/com/mopsicus/umi/MobileInput.java
@@ -658,6 +658,7 @@ public class MobileInput {
     private void SetText(String newText) {
         if (edit != null) {
             edit.setText(newText);
+            edit.setSelection(edit.getText().length());
         }
     }
 


### PR DESCRIPTION

When providing text using setText, 
there was a problem in Android where caret would not go to the end but to the beginning.